### PR TITLE
Urlencode credentials

### DIFF
--- a/3rdparty/tahoma.inc.php
+++ b/3rdparty/tahoma.inc.php
@@ -19,7 +19,11 @@ function tahomaLogon($userId, $userPassword) {
 
 	$url = "https://www.tahomalink.com/enduser-mobile-web/enduserAPI/login";
 
-	$postData = "userId=$userId&userPassword=$userPassword";
+	$postData = sprintf(
+		"userId=%s&userPassword=%s",
+		urlencode($userId),
+		urlencode($userPassword),
+	);
 
 	$ch = curl_init();
 


### PR DESCRIPTION
Credentials containing specials chars breaks authentication. It should be url-encoded.

This PR fixes this case.